### PR TITLE
Stack border buttons vertically on narrow viewports

### DIFF
--- a/app/(tabs)/border.tsx
+++ b/app/(tabs)/border.tsx
@@ -204,14 +204,17 @@ export default function BorderCalculator() {
               </ThemedView>
 
               {/* orientation controls */}
-              <HStack space="md">
+              <Box style={[
+                styles.flipButtons,
+                Platform.OS === 'web' && !isDesktop && styles.flipButtonsNarrow,
+              ]}>
                 <Button onPress={() => setIsLandscape(!isLandscape)} variant="outline">
                   <ButtonText>Flip Paper Orientation</ButtonText>
                 </Button>
                 <Button onPress={() => setIsRatioFlipped(!isRatioFlipped)} variant="outline">
                   <ButtonText>Flip Aspect Ratio</ButtonText>
                 </Button>
-              </HStack>
+              </Box>
 
               {/* result read-out */}
               <ThemedView style={styles.resultContainer}>
@@ -621,4 +624,6 @@ const styles = StyleSheet.create({
   sliderContainer: { flex: 1, marginHorizontal: 8 },
   mobileSliderContainer: { marginTop: 16, width: '100%' },
   offsetRow: { alignItems: 'flex-start', gap: 24 },
+  flipButtons: { flex: 1, flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
+  flipButtonsNarrow: { flexDirection: 'column' },
 });


### PR DESCRIPTION
I noticed on my iPhone that the button would overflow out of the viewport, so I tweaked it so on the narrow breakpoint to stack vertically, like much of the rest of the interface.

<details>
<summary>Before</summary>
<img width="540" alt="Screenshot 2025-06-06 at 12 37 59 🌃" src="https://github.com/user-attachments/assets/8c9ec78d-ced7-409e-a3ab-d9ff6bc5a722" />
</details>

<details>
<summary>After</summary>
<img width="537" alt="Screenshot 2025-06-06 at 12 38 29 🌃" src="https://github.com/user-attachments/assets/ad678ca5-3338-4c71-bc75-e98abcfc63a3" />
</details>